### PR TITLE
version 5.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Note: Even though the entire git development history isn't available on github, 
 [Friendly Release Notes](https://wpclouddeploy.com/category/release-notes/)
 
 ## Change Log ##
+5.8.6
+-----
+* Fix: Resolved the issue with "One Click Login" generation. The problem occurred when the login link was not sent.
+* Enhancement: The WordPress version fetching mechanism was improved Previously, it relied on a manually updated array; this has been upgraded to an API that automatically fetches the latest versions. This is considered a new feature.
+* New: Added apply_filters('wpcd_allowed_min_wp_version', $min_version); to allow users to specify the minimum allowed WordPress version, with a default set to 6.1.4.
+* New: Introduced a new setting (option) named "Min Allowed WP Versions" in the WPCD settings to enable users to set the minimum allowed WordPress version.
+
+
 5.8.5
 ------
 * Fix compatibility issue with MariaDB 10.4+ dump files .

--- a/includes/core/apps/wordpress-app/class-wordpress-app-settings.php
+++ b/includes/core/apps/wordpress-app/class-wordpress-app-settings.php
@@ -1306,6 +1306,14 @@ class WORDPRESS_APP_SETTINGS extends WPCD_APP_SETTINGS {
 				'tab'               => 'wordpress-app-general-wpadmin',
 			),
 			array(
+				'id'                => 'wpcd_allowed_min_wp_version',
+				'type'              => 'text',
+				'size'              => 10,
+				'name'              => __( 'Min Allowed WP Versions', 'wpcd' ),
+				'tooltip'           => __( 'Add the least supported WordPress version or leave it blank.', 'wpcd' ),
+				'tab'               => 'wordpress-app-general-wpadmin',
+			),
+			array(
 				'id'      => 'wordpress_app_versions_show_nightly',
 				'type'    => 'checkbox',
 				'name'    => __( 'Show \'Nightly\' as a Version Option?', 'wpcd' ),

--- a/includes/core/apps/wordpress-app/scripts/v1/raw/30-wp_site_things.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/raw/30-wp_site_things.txt
@@ -303,7 +303,7 @@ if [[ $action == "wp_site_get_passwordless_link" || $action == "8" ]]; then
     admin_user=(${adminusers[@]})
 
     # Get passwordless link
-    link=$(su - $user_name -c "wp login create $admin_user --url-only --expires=180")
+    link=$(su - $user_name -c "wp login create $admin_user --url-only --expires=180 --url=https://$user_name")
 
     echo
     echo $link
@@ -334,7 +334,7 @@ if [[ $action == "wp_site_get_passwordless_link_selected_user" || $action == "9"
     su - $user_name -c "wp login install --activate --yes"
 
     # Get passwordless link
-    link=$(su - $user_name -c "wp login create $login_user --url-only --expires=180")
+    link=$(su - $user_name -c "wp login create $login_user --url-only --expires=180 --url=https://$user_name")
 
     echo
     echo $link

--- a/wpcd.php
+++ b/wpcd.php
@@ -3,7 +3,7 @@
 Plugin Name: WPCloudDeploy
 Plugin URI: https://developvi.com
 Description: Deploy and manage cloud servers and apps from inside the WordPress Admin dashboard.
-Version: 5.8.5
+Version: 5.8.6
 Requires at least: 5.8
 Requires PHP: 7.4
 Item Id: 1493


### PR DESCRIPTION
**Changelog**
* Fix: Resolved the issue with "One Click Login" generation. The problem occurred when the login link was not sent.
* Enhancement: The WordPress version fetching mechanism was improved Previously, it relied on a manually updated array; this has been upgraded to an API that automatically fetches the latest versions. This is considered a new feature.
* New: Added apply_filters('wpcd_allowed_min_wp_version', $min_version); to allow users to specify the minimum allowed WordPress version, with a default set to 6.1.4.
* New: Introduced a new setting (option) named "Min Allowed WP Versions" in the WPCD settings to enable users to set the minimum allowed WordPress version.
