### PR TITLE
Update 58-git_control.txt

### DIFF
--- a/includes/core/apps/wordpress-app/scripts/v1/raw/58-git_control.txt
+++ b/includes/core/apps/wordpress-app/scripts/v1/raw/58-git_control.txt
@@ -2075,29 +2075,39 @@ lf_mt_site_conversion_link_existing_files() {
 		fi
 	done
 
-	echo " 3. mu-plugins"
-	if [ -d "$mt_version_folder/wp-content/mu-plugins" ]; then	
-		echo "    ...mu-plugins exist in source version - linking it."
-		cd "$mt_version_folder/wp-content/mu-plugins/"
-		if [ $? -ne 0 ]
-		then
-			msg="Unable to navigate to $mt_version_folder/wp-content/mu-plugins/"
-			echo
-			echo $msg
-			exit
-		fi	
-		for dir in $(find . -maxdepth 1 -type d -not -name ".*"); do
-			# Create a symbolic link to the subdirectory in the target directory
-			if [ -d "$dir" ]; then
-				local no_slash_folder_name
-				no_slash_folder_name=$(basename "$dir")
-				echo "      ...found mu-plugin in source version: $no_slash_folder_name - linking it."
-				ln -s "$mt_version_folder/wp-content/mu-plugins/$no_slash_folder_name" "$mt_domain_files_folder/wp-content/mu-plugins/$no_slash_folder_name"
-			fi
-		done
-	else
-		echo  "   ...no mu-plugins folder exist in source version, moving on."
-	fi
+        echo " 3. mu-plugins"
+        if [ -d "$mt_version_folder/wp-content/mu-plugins" ]; then
+           echo "    ...mu-plugins exist in source version - linking it."
+            cd "$mt_version_folder/wp-content/mu-plugins/"
+            if [ $? -ne 0 ]; then
+               msg="Unable to navigate to $mt_version_folder/wp-content/mu-plugins/"
+               echo
+               echo $msg
+               exit
+            fi
+
+            # Handle directories
+            for dir in $(find . -maxdepth 1 -type d -not -name ".*"); do
+               if [ -d "$dir" ]; then
+                  local no_slash_folder_name
+                  no_slash_folder_name=$(basename "$dir")
+                  echo "      ...found mu-plugin directory: $no_slash_folder_name - linking it."
+                  ln -s "$mt_version_folder/wp-content/mu-plugins/$no_slash_folder_name" "$mt_domain_files_folder/wp-content/mu-plugins/$no_slash_folder_name"
+               fi
+            done
+
+            # Handle individual PHP files
+            for file in $(find . -maxdepth 1 -type f -name "*.php"); do
+               if [ -f "$file" ]; then
+                  local filename
+                  filename=$(basename "$file")
+                  echo "      ...found mu-plugin file: $filename - linking it."
+                  ln -s "$mt_version_folder/wp-content/mu-plugins/$filename" "$mt_domain_files_folder/wp-content/mu-plugins/$filename"
+               fi
+            done
+        else
+            echo  "   ...no mu-plugins folder exist in source version, moving on."
+        fi
 
 	###################################################################################################
 	# Core files should be COPIED to the site to make sure we're on the same version as the template.


### PR DESCRIPTION
Fix incomplete mu-plugins linking during site version upgrade ﻿
Currently, when upgrading a site to a new site version, the upgrade script only creates symbolic links for subdirectories within the mu-plugins folder, but ignores individual PHP files placed directly in the mu-plugins directory. This is problematic because WordPress mu-plugins can exist in both forms:
1. As standalone .php files directly in the mu-plugins directory
2. As subdirectories containing multiple plugin files ﻿
This patch enhances the mu-plugins upgrade process by:
- Maintaining existing functionality to link subdirectories from the source version
- Adding support to create symbolic links for individual .php files in the mu-plugins root
- Ensuring all mu-plugins are properly linked regardless of their structure ﻿
This fix ensures complete preservation of all must-use plugins when upgrading to a new site version, preventing potential functionality loss during the upgrade process.